### PR TITLE
Switch to building 32-bit version for Windows

### DIFF
--- a/build-sign-deploy.sh
+++ b/build-sign-deploy.sh
@@ -2,7 +2,7 @@
 set -x
 
 # array of target os/arch
-targets=( "darwin/amd64" "linux/amd64" "linux/arm" "windows/amd64" )
+targets=( "darwin/amd64" "linux/amd64" "linux/arm" "windows/386" )
 distPath="../../dist"
 
 # download gpg keys to use for signing
@@ -16,7 +16,7 @@ do
     gox -osarch="${target}" -output="${distPath}/${target}/speedsnitch"
 
     # If OS is windows, append .exe to filename before signing
-    if [ "${target}" == "windows/amd64" ]
+    if [ "${target}" == "windows/386" ]
     then
         fileToSign="${distPath}/${target}/speedsnitch.exe"
     else


### PR DESCRIPTION
Since, I believe, the 32-bit executable should run just fine on 32-bit and on 64-bit versions of Windows, it seems more useful to just build the 32-bit (`386`) version. That also simplifies the Windows installer we're working on.